### PR TITLE
BREAKING CHANGE: Update node to v24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ on:
       - unlabeled
   push:
     branches:
-      - master
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - run: npm ci
     - run: npm test
     - name: Self-test

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
   match:
     description: 'The matched label, if found. Comma-separated if multiple.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'hash'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7024,9 +7024,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow and configuration to use newer standards and versions. The most important changes are grouped below:

Workflow configuration updates:

* Changed the base branch for workflow triggers from `master` to `main` in `.github/workflows/test.yml` to align with current branch naming conventions.
* Updated the GitHub Actions `checkout` step from version 1 to version 6 in `.github/workflows/test.yml` for improved performance and security.

Action configuration updates:

* Upgraded the Node.js runtime from `node20` to `node24` in `action.yml` to use the latest supported version.


⚠️ Should be considered as breaking as requires GitHub runner ([v2.328.0](https://github.com/actions/runner/releases/tag/v2.328.0)) ⚠️